### PR TITLE
fix: remove line length check

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,10 +63,6 @@ impl FIGfont {
             .get(index)
             .ok_or(format!("can't get line at specified index:{}", index))?;
 
-        if line.len() <= 2 {
-            return Err(format!("one line len can't be less than 2. it is:{}", line));
-        }
-
         let mut width = line.len() - 1;
         if is_last_index && height != 1 {
             width -= 1;


### PR DESCRIPTION
It works perfectly fine without that `len` check, so don't particularly see why we need it 🤷 

<img width="1076" alt="Screenshot 2023-02-13 at 19 07 32" src="https://user-images.githubusercontent.com/1528477/218551581-f63ba402-a88e-400a-a53d-aa524bc29532.png">
